### PR TITLE
영화 상세 페이지에서 사용 할 영상 링크를 응답하는 api를 추가한다

### DIFF
--- a/src/api/movieService.js
+++ b/src/api/movieService.js
@@ -13,6 +13,12 @@ class MovieApiService extends BaseApiService {
       .then(BaseApiService.handleResponse)
       .catch(BaseApiService.handleError);
 
+  getMovieVideos = ({ movieId, language = 'en' } = {}) =>
+    this.http
+      .get(`/${movieId}/videos?language=${language}`)
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
+
   getPopularMovies = ({ language = DEFAULT_LANGUAGE, page = 1 } = {}) =>
     this.http
       .get(`/popular?page=${page}&language=${language}`)

--- a/src/constants/swr.js
+++ b/src/constants/swr.js
@@ -1,5 +1,6 @@
 export const USE_SWR_KEYS = {
   MOVIE_DETAIL: 'movie-detail',
+  MOVIE_VIDEOS: 'movie-videos',
   MOVIE_SEARCH: 'movie-search',
   NOW_PLAYING_MOVIES: 'now-playing-movies',
   POPULAR_MOVIES: 'popular-movies',

--- a/src/hooks/api/useMovieVideos.js
+++ b/src/hooks/api/useMovieVideos.js
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+import movieApiService from '@/api/movieService';
+import { USE_SWR_KEYS } from '@/constants/swr';
+
+const useMovieVideos = ({ movieId, language } = {}) => {
+  const { data, error } = useSWR(USE_SWR_KEYS.MOVIE_VIDEOS, () =>
+    movieApiService.getMovieVideos({ movieId, language })
+  );
+
+  return {
+    movie: data,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+
+export default useMovieVideos;


### PR DESCRIPTION
## 변경사항

- 영화 상세 페이지에서 영상을 직접적으로 보여줘야하기 때문에 영상 링크를 응답해주는 api를 추가합니다.
- 응답되는 영상 링크라는건 유튜브의 비디오의 고유한 키값 입니다. youtube api와 함께 활용되어야 합니다.

**타 api와는 다르게 language값을 ko로 했을시 내려오는 영상 링크 응답이 존재하지 않아 해당 api의 language는 en으로 설정했습니다**