### PR TITLE
헤더, 메인, 푸터의 width 통일, 푸터 로고 및 텍스트 크기 축소

### DIFF
--- a/src/components/common/Footer/Footer.jsx
+++ b/src/components/common/Footer/Footer.jsx
@@ -24,7 +24,9 @@ const Footer = () => {
             </a>
           </li>
         </Styled.SnsList>
-        <div>Copyright@원티드 프리 온보딩 2조. All rights reserved</div>
+        <Styled.CopyrightText>
+          Copyright@원티드 프리 온보딩 2조. All rights reserved
+        </Styled.CopyrightText>
       </Styled.Wrapper>
     </Styled.Footer>
   );

--- a/src/components/common/Footer/Footer.styled.js
+++ b/src/components/common/Footer/Footer.styled.js
@@ -27,9 +27,13 @@ const SnsList = styled.ul`
     align-items: center;
   }
   img {
-    width: 30px;
+    width: 20px;
     margin: 0 10px;
   }
 `;
 
-export { Footer, Wrapper, SnsList };
+const CopyrightText = styled.div`
+  font-size: 11px;
+`;
+
+export { Footer, Wrapper, SnsList, CopyrightText };

--- a/src/components/common/PageContainer/PageContainer.styled.js
+++ b/src/components/common/PageContainer/PageContainer.styled.js
@@ -7,7 +7,7 @@ const GlobalContainer = styled.div`
 `;
 
 const Main = styled.main`
-  width: 1100px;
+  width: 1050px;
   margin: 0 auto;
   box-sizing: border-box;
   flex-grow: 1;


### PR DESCRIPTION
## 변경사항

- 헤더, 메인, 푸터의 width 사이즈를 1050px로 통일하였습니다.
- 푸터의 로고 및 텍스트 크기를 축소하였습니다. 
<img width="1439" alt="Screen Shot 2022-09-07 at 6 43 04 PM" src="https://user-images.githubusercontent.com/93869214/188847117-cf621b2d-4d5f-493a-b39a-a79ee20790d2.png">
