### PR TITLE
불필요한 코드 제거 및 early return 적용

### DIFF
--- a/src/components/common/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/common/ScrollToTop/ScrollToTop.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ScrollToTopBtn, UpperImg } from '@/components/common/ScrollToTop/ScrollToTop.styled';
+import { ScrollToTopBtn } from '@/components/common/ScrollToTop/ScrollToTop.styled';
 import imgUp from '@/assets/images/ic-up.png';
 
 const ScrollToTop = () => {
@@ -43,7 +43,7 @@ const ScrollToTop = () => {
 
   return (
     <ScrollToTopBtn onClick={scrollToTop} isDisplay={visibleToTopBtn}>
-      <UpperImg src={imgUp} />
+      <img alt="upImg" src={imgUp} />
     </ScrollToTopBtn>
   );
 };

--- a/src/components/common/ScrollToTop/ScrollToTop.styled.js
+++ b/src/components/common/ScrollToTop/ScrollToTop.styled.js
@@ -14,6 +14,4 @@ const ScrollToTopBtn = styled.div`
   cursor: pointer;
 `;
 
-const UpperImg = styled.img``;
-
-export { ScrollToTopBtn, UpperImg };
+export { ScrollToTopBtn };

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -13,8 +13,9 @@ export const useInfiniteScroll = (onIntersect, options) => {
   );
 
   useEffect(() => {
+    if (!ref.current) return undefined;
     const observer = new IntersectionObserver(handleIntersect, options);
-    if (ref.current) observer.observe(ref.current);
+    observer.observe(ref.current);
 
     return () => observer.disconnect();
   }, [handleIntersect, ref, options]);


### PR DESCRIPTION
## 변경사항

- ScrollToTop에서 불필요하게 사용되고 있었던 UpperImg 제거
- useInfiniteScroll에서 useEffect 부분에 early return패턴 적용